### PR TITLE
fix root home page so jekyll doesnt show the file directly

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -5,6 +5,5 @@
 
 layout: home
 title: Home
-permalink: /home/
-<!-- test comment -->
+permalink: /
 ---


### PR DESCRIPTION
Without the fix, localhost:4000 shows the file directory

# master

<img width="777" alt="image" src="https://github.com/mxddi/lce-club-site/assets/2381771/0bbc5ac2-3d1c-46a5-85cd-d77ea7b8ce3e">

# fix

the root path shows the home screen

<img width="1092" alt="image" src="https://github.com/mxddi/lce-club-site/assets/2381771/dcc5c5c1-0334-4bab-b268-b6c8f7612195">

`/home` still works, so there shouldn't be a broken link

<img width="1131" alt="image" src="https://github.com/mxddi/lce-club-site/assets/2381771/3ffc86b8-1100-45eb-9044-9c07d08f85f9">

